### PR TITLE
Adds Payment Components code samples

### DIFF
--- a/get-started-pc/step-1-1/request.json
+++ b/get-started-pc/step-1-1/request.json
@@ -1,0 +1,16 @@
+{
+  "amount": 1000,
+  "currency": "GBP",
+  "reference": "ORD-123A",
+  "billing": {
+    "address": {
+      "country": "GB"
+    }
+  },
+  "customer": {
+    "name": "John Smith",
+    "email": "john.smith@example.com"
+  },
+  "success_url": "https://example.com/payments/success",
+  "failure_url": "https://example.com/payments/failure"
+}

--- a/get-started-pc/step-1-2/response.json
+++ b/get-started-pc/step-1-2/response.json
@@ -1,0 +1,9 @@
+{
+  "id": "ps_2Un6I6lRpIAiIEwQIyxWVnV9CqQ",
+  "payment_session_token": "YmFzZTY0:eyJpZCI6InBzXzJVbjZJNmxScElBaUlFd1FJeXhXVm5WOUNxUSIsImFtb3VudCI6MTAwMCwibG9jYWxlIjoiZW4tR0IiLCJjdXJyZW5jeSI6IkdCUCIsInBheW1lbnRfbWV0aG9kcyI6W3sidHlwZSI6ImNhcmQiLCJjYXJkX3NjaGVtZXMiOlsiVmlzYSIsIk1hc3RlcmNhcmQiLCJBbWV4Il19XSwicmlzayI6eyJlbmFibGVkIjp0cnVlfSwiX2xpbmtzIjp7InNlbGYiOnsiaHJlZiI6Imh0dHBzOi8vYXBpLnNhbmRib3guY2hlY2tvdXQuY29tL3BheW1lbnQtc2Vzc2lvbnMvcHNfMlVuNkk2bFJwSUFpSUV3UUl5eFdWblY5Q3FRIn19fQ==",
+  "_links": {
+    "self": {
+      "href": "https://api.sandbox.checkout.com/payment-sessions/ps_2Un6I6lRpIAiIEwQIyxWVnV9CqQ"
+    }
+  }
+}

--- a/get-started-pc/step-2-1/1. npm/install-via-npm.sh
+++ b/get-started-pc/step-2-1/1. npm/install-via-npm.sh
@@ -1,0 +1,1 @@
+npm install @checkout.com/checkout-web-components --save

--- a/get-started-pc/step-2-1/2. html/load-via-script.html
+++ b/get-started-pc/step-2-1/2. html/load-via-script.html
@@ -1,0 +1,1 @@
+<script src="https://checkout-web-components.checkout.com/index.js" />

--- a/get-started-pc/step-2-2/1. index.html
+++ b/get-started-pc/step-2-2/1. index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Checkout Web Components: Payments List</title>
+    <link rel="stylesheet" href="normalize.css" />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+
+  <body>
+    <form id="payment-form">
+      <div class="payments-container">
+        <div id="payments"></div>
+      </div>
+      <span id="error-message"></span>
+      <span id="successful-payment-message"></span>
+    </form>
+
+    <script src="https://checkout-web-components.checkout.com/index.js"></script>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/get-started-pc/step-2-2/2. app.js
+++ b/get-started-pc/step-2-2/2. app.js
@@ -1,0 +1,38 @@
+/* global CheckoutWebComponents */
+(async () => {
+  const order = await fetch('/order', { method: 'POST' });
+  const paymentSession = await order.json();
+
+  const checkoutWebComponents = await CheckoutWebComponents({
+    publicKey: 'pk_sbox_...',
+    environment: 'sandbox',
+    locale: 'en-GB',
+    paymentSession,
+    onReady: () => {
+      console.log('onReady');
+    },
+    onPaymentCompleted: (component, paymentResponse) => {
+      const element = document.getElementById('successful-payment-message');
+
+      element.innerHTML = `
+          ${component.name} completed <br>
+          Your payment id is: <span class="payment-id">${paymentResponse.id}</span>
+        `;
+    },
+    onChange: (component) => {
+      console.log('onChange', 'isValid: ', component.isValid(), ' for ', component.type);
+    },
+    onError: (component, error) => {
+      const element = document.getElementById('error-message');
+
+      element.innerHTML = `
+          ${component.name} error <br>
+          Error occurred: <pre class="error-object">${error}</pre>
+        `;
+    },
+  });
+
+  const payments = checkoutWebComponents.create('payments');
+
+  payments.mount(document.getElementById('payments'));
+})();

--- a/get-started-pc/step-2-2/3. style.css
+++ b/get-started-pc/step-2-2/3. style.css
@@ -1,0 +1,17 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  padding: 1rem;
+  background-color: #fff;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+    'Open Sans', 'Helvetica Neue', sans-serif;
+}
+
+#payment-form {
+  max-width: 31.5rem;
+  margin: 0 auto;
+}

--- a/get-started-pc/step-2-2/4. normalize.css
+++ b/get-started-pc/step-2-2/4. normalize.css
@@ -1,0 +1,146 @@
+html {
+  line-height: 1.15;
+  -webkit-text-size-adjust: 100%;
+}
+body {
+  margin: 0;
+}
+main {
+  display: block;
+}
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+hr {
+  box-sizing: content-box;
+  height: 0;
+  overflow: visible;
+}
+pre {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+a {
+  background-color: transparent;
+}
+abbr[title] {
+  border-bottom: none;
+  text-decoration: underline;
+  text-decoration: underline dotted;
+}
+b,
+strong {
+  font-weight: bolder;
+}
+code,
+kbd,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+small {
+  font-size: 80%;
+}
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+sub {
+  bottom: -0.25em;
+}
+sup {
+  top: -0.5em;
+}
+img {
+  border-style: none;
+}
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+}
+button,
+input {
+  overflow: visible;
+}
+button,
+select {
+  text-transform: none;
+}
+[type='button'],
+[type='reset'],
+[type='submit'],
+button {
+  -webkit-appearance: button;
+}
+[type='button']::-moz-focus-inner,
+[type='reset']::-moz-focus-inner,
+[type='submit']::-moz-focus-inner,
+button::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+[type='button']:-moz-focusring,
+[type='reset']:-moz-focusring,
+[type='submit']:-moz-focusring,
+button:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+fieldset {
+  padding: 0.35em 0.75em 0.625em;
+}
+legend {
+  box-sizing: border-box;
+  color: inherit;
+  display: table;
+  max-width: 100%;
+  padding: 0;
+  white-space: normal;
+}
+progress {
+  vertical-align: baseline;
+}
+textarea {
+  overflow: auto;
+}
+[type='checkbox'],
+[type='radio'] {
+  box-sizing: border-box;
+  padding: 0;
+}
+[type='number']::-webkit-inner-spin-button,
+[type='number']::-webkit-outer-spin-button {
+  height: auto;
+}
+[type='search'] {
+  -webkit-appearance: textfield;
+  outline-offset: -2px;
+}
+[type='search']::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+details {
+  display: block;
+}
+summary {
+  display: list-item;
+}
+template {
+  display: none;
+}
+[hidden] {
+  display: none;
+}

--- a/get-started-pc/step-2-3/app.js
+++ b/get-started-pc/step-2-3/app.js
@@ -1,0 +1,5 @@
+const cko = await CheckoutWebComponents({
+  paymentSession,
+  publicKey: 'pk_XXXXXXX',
+  environment: 'sandbox',
+});

--- a/get-started-pc/step-2-4/app.js
+++ b/get-started-pc/step-2-4/app.js
@@ -1,0 +1,1 @@
+const payments = cko.create('payments');

--- a/get-started-pc/step-2-5/app.js
+++ b/get-started-pc/step-2-5/app.js
@@ -1,0 +1,1 @@
+payments.mount('#payments');

--- a/get-started-pc/step-3/app.js
+++ b/get-started-pc/step-3/app.js
@@ -1,0 +1,8 @@
+const cko = await CheckoutWebComponents({
+  paymentSession,
+  publicKey: 'pk_XXXXXXX',
+  onPaymentCompleted: async (_self, paymentResponse) => {
+    // Handle synchronous payments
+    await handlePayment(paymentResponse.id);
+  },
+});


### PR DESCRIPTION
We're updating the Getting Started page on the docs site to use Payment Components instead of Frames.

I've added new samples to the repo that will be used by the new page.

Have not renamed or removed the old samples so we do not break the existing Getting Started page while we update it.